### PR TITLE
Handle perls with no crypt()

### DIFF
--- a/lib/Authen/Simple/Password.pm
+++ b/lib/Authen/Simple/Password.pm
@@ -8,6 +8,9 @@ use Digest::MD5      qw[];
 use Digest::SHA      qw[];
 use MIME::Base64     qw[];
 
+use Config;
+use constant HAVE_CRYPT => $Config{d_crypt};
+
 sub check {
     my ( $class, $password, $encrypted ) = @_;
 
@@ -22,7 +25,7 @@ sub check {
     # $3$ NT-Hash    ?   ?
 
     # Crypt
-    return 1 if crypt( $password, $encrypted ) eq $encrypted;
+    return 1 if HAVE_CRYPT && crypt( $password, $encrypted ) eq $encrypted;
 
     # Crypt Modular Format
     if ( $encrypted =~ /^\$(\w+)\$/ ) {

--- a/t/09password.t
+++ b/t/09password.t
@@ -9,6 +9,9 @@ use Digest::SHA              qw[];
 
 use Test::More tests => 16;
 
+use Config;
+use constant HAVE_CRYPT => $Config{d_crypt};
+
 my @tests = (
     [ 'plain',     'plain',                                  'plain'        ],
     [ 'crypt',     'lk9Mh5KHGjAaM',                          'crypt'        ],
@@ -29,5 +32,9 @@ my @tests = (
 );
 
 foreach my $t ( @tests ) {
-    ok( Authen::Simple::Password->check( $t->[0], $t->[1] ), $t->[2] );
+    SKIP: {
+        skip "crypt not available on this system", 1
+            if !HAVE_CRYPT && $t->[0] eq 'crypt';
+        ok( Authen::Simple::Password->check( $t->[0], $t->[1] ), $t->[2] );
+    }
 }


### PR DESCRIPTION
Technically this affects any perl built with -Ud_crypt, but realistically, only affects Android, where the underlaying C library doesn't provide a crypt()
