### PR TITLE
test for SHA || MD5 passwords before testing problematic crypt().

### DIFF
--- a/lib/Authen/Simple.pm
+++ b/lib/Authen/Simple.pm
@@ -5,7 +5,7 @@ use warnings;
 
 use Params::Validate qw[];
 
-our $VERSION = '0.5';
+our $VERSION = '0.6';
 
 sub new {
     my $class = shift;
@@ -112,6 +112,8 @@ L<Authen::Simple::SSH>.
 =head1 AUTHOR
 
 Christian Hansen C<chansen@cpan.org>
+Brian Fraser
+David A. Horner <dave@thehorners.com>
 
 =head1 COPYRIGHT
 

--- a/lib/Authen/Simple/Password.pm
+++ b/lib/Authen/Simple/Password.pm
@@ -24,9 +24,6 @@ sub check {
     # $2$ Blowfish  34  16
     # $3$ NT-Hash    ?   ?
 
-    # Crypt
-    return 1 if HAVE_CRYPT && crypt( $password, $encrypted ) eq $encrypted;
-
     # Crypt Modular Format
     if ( $encrypted =~ /^\$(\w+)\$/ ) {
         return 1 if $class->_check_modular( $password, $encrypted, lc($1) );
@@ -75,6 +72,9 @@ sub check {
     if ( length($encrypted) == 64 ) {
         return 1 if Digest::SHA::sha256_hex($password) eq $encrypted;
     }
+
+    # Crypt
+    return 1 if HAVE_CRYPT && crypt( $password, $encrypted ) eq $encrypted;
 
     return 0;
 }


### PR DESCRIPTION
strawberry perl crypt was crashing during t/password.t
for more background check: https://rt.cpan.org/Ticket/Display.html?id=100750
