### PR TITLE
add '.' to @INC for Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,5 @@
 use strict;
+use lib '.';
 use inc::Module::Install;
 
 name           'Authen-Simple';


### PR DESCRIPTION
Perl 5.25.11 and later (including 5.26.0 when it is released)
removes '.' from @INC by default.  Under this configuration
the installer is broken, this patch will fix that.